### PR TITLE
Removed deprecated 'conflicts_with' stanza declaration

### DIFF
--- a/Casks/install-unity.rb
+++ b/Casks/install-unity.rb
@@ -2,8 +2,6 @@ cask 'install-unity' do
   version '2.13.1'
   sha256 '43b27a1c9cd01203541aa4aa7162f2af2800bcd27af636787107a2cfdf18d0cb'
 
-  conflicts_with formula: 'install-unity'
-
   url "https://github.com/sttz/install-unity/releases/download/#{version}/install-unity-#{version}.zip"
   name 'install-unity'
   homepage 'https://github.com/sttz/install-unity/'


### PR DESCRIPTION
Error: Cask 'install-unity' definition is invalid: 'conflicts_with' stanza failed with: Calling conflicts_with formula: is disabled! There is no replacement.